### PR TITLE
Bugfix the 6x JSON template for compatibility with ES 6.6.1.

### DIFF
--- a/varnishstatbeat.template-es6x.json
+++ b/varnishstatbeat.template-es6x.json
@@ -15,8 +15,8 @@
           "strings_as_keyword": {
             "mapping": {
               "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
+              "index": false,
+              "type": "text"
             },
             "match_mapping_type": "string"
           }
@@ -29,19 +29,16 @@
         "beat": {
           "properties": {
             "hostname": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
+              "index": false,
+              "type": "text"
             },
             "name": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
+              "index": false,
+              "type": "text"
             },
             "version": {
-              "ignore_above": 1024,
-              "index": "not_analyzed",
-              "type": "string"
+              "index": false,
+              "type": "text"
             }
           }
         },
@@ -56,43 +53,36 @@
             "cloud": {
               "properties": {
                 "availability_zone": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "index": false,
+                  "type": "text"
                 },
                 "instance_id": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "index": false,
+                  "type": "text"
                 },
                 "machine_type": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "index": false,
+                  "type": "text"
                 },
                 "project_id": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "index": false,
+                  "type": "text"
                 },
                 "provider": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "index": false,
+                  "type": "text"
                 },
                 "region": {
-                  "ignore_above": 1024,
-                  "index": "not_analyzed",
-                  "type": "string"
+                  "index": false,
+                  "type": "text"
                 }
               }
             }
           }
         },
         "tags": {
-          "ignore_above": 1024,
-          "index": "not_analyzed",
-          "type": "string"
+          "index": false,
+          "type": "text"
         }
       }
     }


### PR DESCRIPTION
* Type "string" has been changed to "text".
* "index" must be boolean false (in place of "not_analyzed").
* "ignore_above" is not compatible with most type "text" fields.

ES apparently does not object to "ignore_above" used in the "strings_as_keyword" mapping declaration.

This fix gets varnishbeat to run with ES 6.6.1 on my system -- I can view the stats successfully with Kibana.

Closes #3 